### PR TITLE
fix: chat presend로 인한 오류 해결

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -343,7 +343,7 @@
 
   function signUpRequest() {
     var settings = {
-      url: "http://localhost:8080/api/auth/signup",
+      url: "http://43.200.42.252:8080:8080/api/auth/signup",
       method: "POST",
       timeout: 0,
       headers: {
@@ -367,7 +367,7 @@
 
   function signInRequest() {
     var settings = {
-      url: "http://localhost:8080/api/auth/signin",
+      url: "http://43.200.42.252:8080/api/auth/signin",
       method: "POST",
       timeout: 0,
       headers: {

--- a/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/config/StompSessionInterceptor.java
+++ b/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/config/StompSessionInterceptor.java
@@ -13,6 +13,7 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.SQLOutput;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,8 +32,12 @@ public class StompSessionInterceptor implements ChannelInterceptor {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
         var sessionId = accessor.getSessionId();
         switch (accessor.getCommand()) {
-
             case SEND:
+
+                if (accessor.getDestination().equals("/pub/chat/message")) {
+                    break;
+                }
+
                 byte[] a = (byte[]) message.getPayload();
                 String data = new String(a);
                 try {


### PR DESCRIPTION
채팅과 매칭이 동일한 설정을 사용함에 있어서 생긴 문제
StompSessionInterceptor로 클라이언트의 요청들이 인터셉터 되었고 매칭에 관련한 로직을 타게 되었음
채팅은 해당하는 로직에 필요한 데이터들이 없어서 exception 발생
subscribe는 되지만 send는 안 되었던 이유는 handler에서 switch문으로 send와 disconnect만 잡았기 때문에 subscribe는 잡히지 않아 그냥 바로 return message 되어 문제가 없었음

(+) index.html의 ajax url 수정 / localhost -> aws