### PR TITLE
멤버 프로필 기능 수정 PR

### DIFF
--- a/docs/board/board.html
+++ b/docs/board/board.html
@@ -172,7 +172,7 @@
                       class="form-control"
                       id="message"
                       rows="3"
-                      placeholder="문구를 입력해주세요. 사진은 필수입니다."
+                      placeholder="문구를 입력해주세요."
                     ></textarea>
                   </div>
                 </div>
@@ -629,7 +629,7 @@
                         <div class="d-flex justify-content-between align-items-center">
                             <div class="d-flex justify-content-between align-items-center">
                                 <div class="mr-2">
-                                    <img class="rounded-circle" width="45" src="${this.memberImage}" alt="">
+                                    <img class="rounded-circle" width="45" src="https://game-matching.s3.ap-northeast-2.amazonaws.com/${this.memberImage}" alt="">
                                 </div>
                                 <div class="ml-2">
                                     <input type="hidden" id="boardId" value="boardId">
@@ -653,7 +653,7 @@
                     </div>
                     <div class="card-body" style="padding: 0;">
                         <div style="position: relative;">
-                            <img src="${this.boardImage}" alt="" style="width: 100%; height: 100%; object-fit: cover;">
+                            <img src="https://game-matching.s3.ap-northeast-2.amazonaws.com/${this.boardImage}" alt="" style="width: 100%; height: 100%; object-fit: cover;">
                             <div class="text-muted h7 mb-2" style="position: absolute; bottom: 1%; padding-left: 15px;"> <i
                                     class="fa fa-clock-o"></i>${this.modifiedAt}</div>
                         </div>
@@ -791,7 +791,7 @@
 
           let temp_html = `<div class="comment">
                                 <div class="comment-header">
-                                    <img class="rounded-circle" width="30" height="30" src="${this.memberImage}" alt="">
+                                    <img class="rounded-circle" width="30" height="30" src="https://game-matching.s3.ap-northeast-2.amazonaws.com/${this.memberImage}" alt="">
                                     <p>${this.nickname}</p>
                                     <div class="dropdown">
                                         <button id="boardId" value="" class="btn btn-link dropdown-toggle" type="button" id="gedf-drop1" data-toggle="dropdown"

--- a/docs/chat/chat.html
+++ b/docs/chat/chat.html
@@ -1,459 +1,483 @@
-<html>
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chat</title>
 
-<head>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
-    <link href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" rel="stylesheet" id="bootstrap-css">
+    <link
+      href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
+      rel="stylesheet"
+      id="bootstrap-css"
+    />
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"></script>
-    <script src="https://kit.fontawesome.com/0f7e35127c.js" crossorigin="anonymous"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" type="text/css"
-        rel="stylesheet">
+    <script
+      src="https://kit.fontawesome.com/0f7e35127c.js"
+      crossorigin="anonymous"
+    ></script>
+    <link
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css"
+      type="text/css"
+      rel="stylesheet"
+    />
+  </head>
 
-</head>
-
-<body>
+  <body>
     <nav class="navbar navbar-light bg-white">
-        <img href="#" class="" src="../images/nav/logo.png" />
+      <img href="#" class="" src="../images/nav/logo.png" />
     </nav>
 
     <nav class="menu">
-        <div class="menu__list">
-            <li class="menu__btn">
-                <a class="menu__link" href="/board/board.html">
-                    <div class="menu__link__explain">
-                        <!-- <span><i class="fa-solid fa-clipboard-user fa-lg"></i></span> -->
-                        <span>📝 일반 게시판</span>
-                    </div>
-                </a>
-            </li>
-    
-            <li class="menu__btn">
-                <a class="menu__link" href="/board/anonymous-board.html">
-                    <div class="menu__link__explain">
-                        <!-- <span><i class="fa-solid fa-clipboard-question fa-lg"></i></span> -->
-                        <span>📝 익명 게시판</span>
-                    </div>
-                </a>
-            </li>
-    
-            <li class="menu__btn" style="background-color: #b1bce66c;">
-                <a class="menu__link" href="/chat/chat.html">
-                    <div class="menu__link__explain">
-                        <!-- <span><i class="fa-solid fa-comment fa-lg"></i></span> -->
-                        <span>✉️ 메시지</span>
-                    </div>
-                </a>
-            </li>
-    
-            <li class="menu__btn">
-                <a class="menu__link" href="/matching/matching-request.html">
-                    <div class="menu__link__explain">
-                        <!-- <span><i class="fa-solid fa-gamepad"></i></span> -->
-                        <span>🎮 매칭</span>
-                    </div>
-                </a>
-            </li>
-    
-            <li class="menu__btn">
-                <a class="menu__link" href="/profile/my-profile.html">
-                    <div class="menu__link__explain">
-                        <!-- <i class="fa-solid fa-user fa-lg"></i> -->
-                        <span>🙇🏻‍♀️ 프로필</span>
-                    </div>
-                </a>
-            </li>
-        </div>
+      <div class="menu__list">
+        <li class="menu__btn">
+          <a class="menu__link" href="/board/board.html">
+            <div class="menu__link__explain">
+              <!-- <span><i class="fa-solid fa-clipboard-user fa-lg"></i></span> -->
+              <span>📝 일반 게시판</span>
+            </div>
+          </a>
+        </li>
+
+        <li class="menu__btn">
+          <a class="menu__link" href="/board/anonymous-board.html">
+            <div class="menu__link__explain">
+              <!-- <span><i class="fa-solid fa-clipboard-question fa-lg"></i></span> -->
+              <span>📝 익명 게시판</span>
+            </div>
+          </a>
+        </li>
+
+        <li class="menu__btn" style="background-color: #b1bce66c">
+          <a class="menu__link" href="/chat/chat.html">
+            <div class="menu__link__explain">
+              <!-- <span><i class="fa-solid fa-comment fa-lg"></i></span> -->
+              <span>✉️ 메시지</span>
+            </div>
+          </a>
+        </li>
+
+        <li class="menu__btn">
+          <a class="menu__link" href="/matching/matching-request.html">
+            <div class="menu__link__explain">
+              <!-- <span><i class="fa-solid fa-gamepad"></i></span> -->
+              <span>🎮 매칭</span>
+            </div>
+          </a>
+        </li>
+
+        <li class="menu__btn">
+          <a class="menu__link" href="/profile/my-profile.html">
+            <div class="menu__link__explain">
+              <!-- <i class="fa-solid fa-user fa-lg"></i> -->
+              <span>🙇🏻‍♀️ 프로필</span>
+            </div>
+          </a>
+        </li>
+      </div>
     </nav>
 
     <div class="container">
-        <div class="messaging">
-            <div class="inbox_msg">
-                <div class="inbox_people">
-                    <div class="headind_srch">
-                        <h4 class="budae-font">즐빡 친구</h4>
-                    </div>
-                    <div class="inbox_chat" id="friend-list">
-                        <!-- 친구 목록 오는 부분 -->
-                    </div>
-                </div>
-                <div class="mesgs">
-                    <div class="msg_history" id="msg-history">
-                        <!-- 메세지 오는 부분 -->
-                    </div>
-                    <div class="type_msg">
-                        <div class="input_msg_write">
-                            <input id="msg" type="text" class="write_msg" placeholder="메세지를 입력하세요." />
-                            <button class="msg_send_btn" type="button" style="outline: none;" id="send-btn">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="33" height="33" fill="currentColor"
-                                    class="bi bi-arrow-up-short" viewBox="0 0 16 16" aria-hidden="true">
-                                    <path fill-rule="evenodd"
-                                        d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z" />
-                                </svg>
-                            </button>
-                        </div>
-                    </div>
-                </div>
+      <div class="messaging">
+        <div class="inbox_msg">
+          <div class="inbox_people">
+            <div class="headind_srch">
+              <h4 class="budae-font">즐빡 친구</h4>
             </div>
-
+            <div class="inbox_chat" id="friend-list">
+              <!-- 친구 목록 오는 부분 -->
+            </div>
+          </div>
+          <div class="mesgs">
+            <div class="msg_history" id="msg-history">
+              <!-- 메세지 오는 부분 -->
+            </div>
+            <div class="type_msg">
+              <div class="input_msg_write">
+                <input
+                  id="msg"
+                  type="text"
+                  class="write_msg"
+                  placeholder="메세지를 입력하세요."
+                />
+                <button
+                  class="msg_send_btn"
+                  type="button"
+                  style="outline: none"
+                  id="send-btn"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="33"
+                    height="33"
+                    fill="currentColor"
+                    class="bi bi-arrow-up-short"
+                    viewBox="0 0 16 16"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M8 12a.5.5 0 0 0 .5-.5V5.707l2.146 2.147a.5.5 0 0 0 .708-.708l-3-3a.5.5 0 0 0-.708 0l-3 3a.5.5 0 1 0 .708.708L7.5 5.707V11.5a.5.5 0 0 0 .5.5z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
+      </div>
     </div>
-</body>
-
+  </body>
 </html>
 
 <style>
-    @font-face {
-        font-family: 'TTTtangsbudaejjigaeB';
-        src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2212@1.0/TTTtangsbudaejjigaeB.woff2') format('woff2');
-        font-weight: 700;
-        font-style: normal;
-    }
+  @font-face {
+    font-family: "TTTtangsbudaejjigaeB";
+    src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2212@1.0/TTTtangsbudaejjigaeB.woff2")
+      format("woff2");
+    font-weight: 700;
+    font-style: normal;
+  }
 
-    .budae-font {
-        font-family: 'TTTtangsbudaejjigaeB';
-    }
+  .budae-font {
+    font-family: "TTTtangsbudaejjigaeB";
+  }
 
-    body {
-        background-color: #b1bce62f;
-    }
+  body {
+    background-color: #b1bce62f;
+  }
 
-    nav img {
-        width: 50px;
-    }
+  nav img {
+    width: 50px;
+  }
 
-    .container {
-        max-width: 60%;
-        width: auto;
-        margin: auto;
-        margin-top: 55px;
-        margin-left: 400px;
-    }
+  .container {
+    max-width: 60%;
+    width: auto;
+    margin: auto;
+    margin-top: 55px;
+    margin-left: 400px;
+  }
 
-    img {
-        max-width: 100%;
-    }
+  img {
+    max-width: 100%;
+  }
 
+  .inbox_people {
+    background: #fff;
+    float: left;
+    overflow: hidden;
+    width: 40%;
+    border-right: 1px solid #d6d6d6;
+    height: 530px;
+  }
 
-    .inbox_people {
-        background: #fff;
-        float: left;
-        overflow: hidden;
-        width: 40%;
-        border-right: 1px solid #d6d6d6;
-        height: 530px;
-    }
+  .inbox_msg {
+    /* border: 1px solid #c4c4c4; */
+    border-radius: 10px;
+    clear: both;
+    overflow: hidden;
+    background-color: #fff;
+  }
 
-    .inbox_msg {
-        /* border: 1px solid #c4c4c4; */
-        border-radius: 10px;
-        clear: both;
-        overflow: hidden;
-        background-color: #fff;
-    }
+  .top_spac {
+    margin: 20px 0 0;
+  }
 
-    .top_spac {
-        margin: 20px 0 0;
-    }
+  .srch_bar {
+    display: inline-block;
+    text-align: right;
+    width: 60%;
+  }
 
-    .srch_bar {
-        display: inline-block;
-        text-align: right;
-        width: 60%;
-    }
+  .headind_srch {
+    padding: 17px 29px 13px 20px;
+    overflow: hidden;
+    border-bottom: 1px solid #c4c4c4;
+    text-align: center;
+  }
 
-    .headind_srch {
-        padding: 17px 29px 13px 20px;
-        overflow: hidden;
-        border-bottom: 1px solid #c4c4c4;
-        text-align: center;
-    }
+  .headind_srch h4 {
+    color: #9a86a4;
+    font-size: 21px;
+    margin: auto;
+  }
 
-    .headind_srch h4 {
-        color: #9A86A4;
-        font-size: 21px;
-        margin: auto;
-    }
+  .chat_ib h5 {
+    margin: 0;
+    font-size: 15px;
+    color: #464646;
+  }
 
-    .chat_ib h5 {
-        margin: 0;
-        font-size: 15px;
-        color: #464646;
-    }
+  .chat_ib h5 span {
+    font-size: 13px;
+    float: right;
+  }
 
-    .chat_ib h5 span {
-        font-size: 13px;
-        float: right;
-    }
+  .chat_ib p {
+    font-size: 14px;
+    color: #989898;
+    margin: auto;
+  }
 
-    .chat_ib p {
-        font-size: 14px;
-        color: #989898;
-        margin: auto
-    }
+  .chat_img {
+    float: left;
+    width: 11%;
+  }
 
-    .chat_img {
-        float: left;
-        width: 11%;
-    }
+  .chat_ib {
+    float: left;
+    padding: 0 0 0 15px;
+    width: 88%;
+  }
 
-    .chat_ib {
-        float: left;
-        padding: 0 0 0 15px;
-        width: 88%;
-    }
+  .chat_people {
+    overflow: hidden;
+    clear: both;
+    display: flex;
+    align-items: center;
+  }
 
-    .chat_people {
-        overflow: hidden;
-        clear: both;
-        display: flex;
-        align-items: center;
-    }
+  .chat_list {
+    border-bottom: 1px solid #c4c4c4;
+    margin: 0;
+    padding: 13px 16px 13px 16px;
+  }
 
-    .chat_list {
-        border-bottom: 1px solid #c4c4c4;
-        margin: 0;
-        padding: 13px 16px 13px 16px;
-    }
+  .inbox_chat {
+    height: 545px;
+    overflow-y: scroll;
+  }
 
-    .inbox_chat {
-        height: 545px;
-        overflow-y: scroll;
-    }
+  .active_chat {
+    background: #b1bce66c;
+  }
 
-    .active_chat {
-        background: #b1bce66c;
-    }
+  .incoming_msg_img {
+    display: inline-block;
+    width: 6%;
+  }
 
-    .incoming_msg_img {
-        display: inline-block;
-        width: 6%;
-    }
+  .received_msg {
+    display: inline-block;
+    padding: 0 0 0 10px;
+    vertical-align: top;
+    width: 92%;
+  }
 
-    .received_msg {
-        display: inline-block;
-        padding: 0 0 0 10px;
-        vertical-align: top;
-        width: 92%;
-    }
+  .received_withd_msg p {
+    background: #ebebeb none repeat scroll 0 0;
+    border-radius: 3px;
+    color: #646464;
+    font-size: 14px;
+    margin: 0;
+    padding: 5px 10px 5px 12px;
+    width: 100%;
+  }
 
-    .received_withd_msg p {
-        background: #ebebeb none repeat scroll 0 0;
-        border-radius: 3px;
-        color: #646464;
-        font-size: 14px;
-        margin: 0;
-        padding: 5px 10px 5px 12px;
-        width: 100%;
-    }
+  .received_withd_msg {
+    width: 57%;
+  }
 
-    .received_withd_msg {
-        width: 57%;
-    }
+  .mesgs {
+    float: left;
+    padding: 30px 15px 0 25px;
+    width: 60%;
+  }
 
-    .mesgs {
-        float: left;
-        padding: 30px 15px 0 25px;
-        width: 60%;
-    }
+  .sent_msg p {
+    background: #9a86a4 none repeat scroll 0 0;
+    border-radius: 3px;
+    font-size: 14px;
+    margin: 0;
+    color: #fff;
+    padding: 5px 10px 5px 12px;
+    width: 100%;
+  }
 
-    .sent_msg p {
-        background: #9A86A4 none repeat scroll 0 0;
-        border-radius: 3px;
-        font-size: 14px;
-        margin: 0;
-        color: #fff;
-        padding: 5px 10px 5px 12px;
-        width: 100%;
-    }
+  .outgoing_msg {
+    overflow: hidden;
+    margin: 26px 0 26px;
+  }
 
-    .outgoing_msg {
-        overflow: hidden;
-        margin: 26px 0 26px;
-    }
+  .sent_msg {
+    float: right;
+    width: 46%;
+  }
 
-    .sent_msg {
-        float: right;
-        width: 46%;
-    }
+  .input_msg_write input {
+    background: rgba(0, 0, 0, 0) none repeat scroll 0 0;
+    border: medium none;
+    color: #4c4c4c;
+    font-size: 15px;
+    min-height: 48px;
+    width: 89%;
+    outline: none;
+    padding-top: 7px;
+  }
 
-    .input_msg_write input {
-        background: rgba(0, 0, 0, 0) none repeat scroll 0 0;
-        border: medium none;
-        color: #4c4c4c;
-        font-size: 15px;
-        min-height: 48px;
-        width: 89%;
-        outline: none;
-        padding-top: 7px;
-    }
+  .type_msg {
+    border-top: 1px solid #c4c4c4;
+    position: relative;
+    outline: none;
+  }
 
-    .type_msg {
-        border-top: 1px solid #c4c4c4;
-        position: relative;
-        outline: none;
-    }
+  .msg_send_btn {
+    background: #b1bce6 none repeat scroll 0 0;
+    border: none;
+    border-radius: 50%;
+    color: #fff;
+    cursor: pointer;
+    font-size: 17px;
+    height: 33px;
+    position: absolute;
+    right: 2px;
+    top: 10px;
+    width: 33px;
+    outline: none;
+    padding: 0;
+  }
 
-    .msg_send_btn {
-        background: #B1BCE6 none repeat scroll 0 0;
-        border: none;
-        border-radius: 50%;
-        color: #fff;
-        cursor: pointer;
-        font-size: 17px;
-        height: 33px;
-        position: absolute;
-        right: 2px;
-        top: 10px;
-        width: 33px;
-        outline: none;
-        padding: 0;
-    }
+  .svg {
+    display: flex;
+  }
 
-    .svg {
-        display: flex;
-    }
+  .msg_history {
+    height: 440px;
+    overflow-y: auto;
+  }
 
-    .msg_history {
-        height: 440px;
-        overflow-y: auto;
-    }
+  /* 메뉴바 */
 
-    /* 메뉴바 */
+  .menu {
+    background-color: #fff;
+    padding: 10px 0;
+    border-top: 1px solid rgba(0, 0, 0, 0.05);
+    border-radius: 10px;
+    position: fixed;
+    top: 0;
+    box-sizing: border-box;
+    width: 170px;
+    display: flex;
+    flex-direction: column;
+    margin-left: 110px;
+    margin-top: 120px;
+    text-align: center;
+    /* box-shadow: 3px 3px #9A86A4; */
+  }
 
-    .menu {
-        background-color: #fff;
-        padding: 10px 0;
-        border-top: 1px solid rgba(0, 0, 0, 0.05);
-        border-radius: 10px;
-        position: fixed;
-        top: 0;
-        box-sizing: border-box;
-        width: 170px;
-        display: flex;
-        flex-direction: column;
-        margin-left: 110px;
-        margin-top: 120px;
-        text-align: center;
-        /* box-shadow: 3px 3px #9A86A4; */
-    }
+  .menu a {
+    text-decoration: none;
+    color: black;
+  }
 
-    .menu a {
-        text-decoration: none;
-        color: black;
-    }
+  .menu li {
+    list-style: none;
+  }
 
-    .menu li {
-        list-style: none;
-    }
+  .menu__btn {
+    padding: 10px 0;
+  }
 
-    .menu__btn {
-        padding: 10px 0;
-    }
-
-    .menu__link__explain {
-        display: flex;
-        font-size: 12px;
-        /* justify-content: center; */
-        padding-left: 20px;
-    }
+  .menu__link__explain {
+    display: flex;
+    font-size: 12px;
+    /* justify-content: center; */
+    padding-left: 20px;
+  }
 </style>
 
 <script>
-    const auth = localStorage.getItem('Authorization');
+  const auth = localStorage.getItem("Authorization");
 
-    // 친구리스트 불러오기
+  // 친구리스트 불러오기
 
-    $(document).ready(function () {
-        showFriend()
-    });
+  $(document).ready(function () {
+    showFriend();
+  });
 
-    function showFriend() {
-        $.ajax({
-            type: "GET",
-            url: "http://43.200.42.252:8080/api/chat/friends",
-            beforeSend: function (xhr) {
-                xhr.setRequestHeader("Authorization", auth);
-            },
-            data: {},
-            error: function (e) {
-                console.log("친구 불러오기 오류");
-                console.log(e);
-            },
-            success: function (response) {
-                for (let i = 0; i < response.length; i++) {
-                    let nickname = response[i].profile.nickname;
-                    let profile_img;
+  function showFriend() {
+    $.ajax({
+      type: "GET",
+      url: "http://43.200.42.252:8080/api/chat/friends",
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader("Authorization", auth);
+      },
+      data: {},
+      error: function (e) {
+        console.log("친구 불러오기 오류");
+        console.log(e);
+      },
+      success: function (response) {
+        for (let i = 0; i < response.length; i++) {
+          let nickname = response[i].profile.nickname;
+          let profile_img;
 
-                    if (profile_img == null) {
-                        profile_img = "/images/common/logo.png"
-                    } else {
-                        profile_img = response[i].profile.profileImage;
-                    }
+          if (profile_img == null) {
+            profile_img = "images/nav/logo.png";
+          } else {
+            profile_img = response[i].profile.profileImage;
+          }
 
-                    let temp_html = `<div class="chat_list" onclick="showChat('${nickname}')">
+          let temp_html = `<div class="chat_list" onclick="showChat('${nickname}')">
               <div class="chat_people">
-                <div class="chat_img"> <img src="${profile_img}"> </div>
+                <div class="chat_img"> <img src="https://game-matching.s3.ap-northeast-2.amazonaws.com/${profile_img}"> </div>
                 <div class="chat_ib">
                   <h5>${nickname}</h5>
                 </div>
               </div>
             </div>`;
 
-                    $(`#friend-list`).append(temp_html);
-                }
-            }
-        });
-    }
+          $(`#friend-list`).append(temp_html);
+        }
+      },
+    });
+  }
 
-    //클릭 시, 채팅 연결 및 채팅창 보이기
-    function showChat(fnickname) {
+  //클릭 시, 채팅 연결 및 채팅창 보이기
+  function showChat(fnickname) {
+    $.ajax({
+      type: "GET",
+      url: "http://43.200.42.252:8080/api/chat/room/enter/" + fnickname,
+      contentType: "application/json",
+      data: {},
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader("Authorization", auth);
+      },
+      error: function (e) {
+        console.log(e);
+      },
+      success: function (response) {
+        let roomId = response.id;
+        //stomp로 topic 연결 및 구독
+        connect(roomId, fnickname);
+      },
+    });
+  }
 
-        $.ajax({
-            type: "GET",
-            url: "http://43.200.42.252:8080/api/chat/room/enter/" + fnickname,
-            contentType: "application/json",
-            data: {},
-            beforeSend: function (xhr) {
-                xhr.setRequestHeader("Authorization", auth);
-            },
-            error: function (e) {
-                console.log(e);
-            },
-            success: function (response) {
+  function connect(roomId, fnick) {
+    getMessage(roomId, fnick);
 
-                let roomId = response.id;
-                //stomp로 topic 연결 및 구독
-                connect(roomId, fnickname);
+    var sockJs = new SockJS("http://43.200.42.252:8080/GGTalk");
+    var stomp = Stomp.over(sockJs);
 
-            }
-        })
+    stomp.connect({}, function () {
+      console.log("stomp 연결");
 
-    }
+      stomp.subscribe("/sub/chat/room/" + roomId, function (response) {
+        console.log("stomp 구독");
+        console.log(response);
 
-    function connect(roomId, fnick) {
+        var content = JSON.parse(response.body);
+        var receiver = content.receiver;
+        var message = content.message;
 
-        getMessage(roomId, fnick);
-
-        var sockJs = new SockJS("http://43.200.42.252:8080/GGTalk");
-        var stomp = Stomp.over(sockJs);
-
-        stomp.connect({}, function () {
-
-            console.log("stomp 연결");
-
-            stomp.subscribe("/sub/chat/room/" + roomId, function (response) {
-
-                console.log("stomp 구독");
-                console.log(response);
-
-                var content = JSON.parse(response.body);
-                var receiver = content.receiver;
-                var message = content.message;
-
-                //sender가 fnick이랑 같으면 왼쪽 말풍선 추가
-                if (receiver != fnick) {
-                    temp_html = `<div class="incoming_msg">
+        //sender가 fnick이랑 같으면 왼쪽 말풍선 추가
+        if (receiver != fnick) {
+          temp_html = `<div class="incoming_msg">
               <div class="incoming_msg_img"> <img src="https://ptetutorials.com/images/user-profile.png" alt="sunil">
               </div>
               <div class="received_msg">
@@ -461,53 +485,54 @@
                   <p>${message}</p>
                 </div>
               </div>
-            </div>`
-                }
-                //sender가 fnick이랑 다르면 오른쪽 말풍선 추가
-                else {
-                    temp_html = `<div class="outgoing_msg">
+            </div>`;
+        }
+        //sender가 fnick이랑 다르면 오른쪽 말풍선 추가
+        else {
+          temp_html = `<div class="outgoing_msg">
               <div class="sent_msg">
                 <p>${message}</p>
               </div>
-            </div>`
-                }
+            </div>`;
+        }
 
-                $(`#msg-history`).append(temp_html);
-            });
-        });
+        $(`#msg-history`).append(temp_html);
+      });
+    });
 
-        $("#send-btn").on("click", function (e) {
-            var msg = document.getElementById("msg");
+    $("#send-btn").on("click", function (e) {
+      var msg = document.getElementById("msg");
 
-            stomp.send('/pub/chat/message', {}, JSON.stringify({ roomId: roomId, message: msg.value, receiver: fnick }));
-            msg.value = '';
-        });
+      stomp.send(
+        "/pub/chat/message",
+        {},
+        JSON.stringify({ roomId: roomId, message: msg.value, receiver: fnick })
+      );
+      msg.value = "";
+    });
+  }
 
+  function getMessage(roomId, fnick) {
+    $(`#msg-history`).empty();
 
-    }
+    $.ajax({
+      type: "GET",
+      url: "http://43.200.42.252:8080/api/chat/room/" + roomId + "/message",
+      data: {},
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader("Authorization", auth);
+      },
+      error: function (e) {
+        console.log(e);
+      },
+      success: function (response) {
+        for (let i = 0; i < response.length; i++) {
+          let receiver = response[i].receiver;
+          let message = response[i].message;
 
-    function getMessage(roomId, fnick) {
-        $(`#msg-history`).empty();
-
-        $.ajax({
-            type: "GET",
-            url: "http://43.200.42.252:8080/api/chat/room/" + roomId + "/message",
-            data: {},
-            beforeSend: function (xhr) {
-                xhr.setRequestHeader("Authorization", auth);
-            },
-            error: function (e) {
-                console.log(e);
-            },
-            success: function (response) {
-
-                for (let i = 0; i < response.length; i++) {
-                    let receiver = response[i].receiver;
-                    let message = response[i].message;
-
-                    //sender가 fnick이랑 같으면 왼쪽 말풍선 추가
-                    if (receiver == fnick) {
-                        temp_html = `<div class="incoming_msg">
+          //sender가 fnick이랑 같으면 왼쪽 말풍선 추가
+          if (receiver != fnick) {
+            temp_html = `<div class="incoming_msg">
               <div class="incoming_msg_img"> <img src="https://ptetutorials.com/images/user-profile.png" alt="sunil">
               </div>
               <div class="received_msg">
@@ -515,24 +540,20 @@
                   <p>${message}</p>
                 </div>
               </div>
-            </div>`
-                    }
-                    //sender가 fnick이랑 다르면 오른쪽 말풍선 추가
-                    else {
-                        temp_html = `<div class="outgoing_msg">
+            </div>`;
+          }
+          //sender가 fnick이랑 다르면 오른쪽 말풍선 추가
+          else {
+            temp_html = `<div class="outgoing_msg">
               <div class="sent_msg">
                 <p>${message}</p>
               </div>
-            </div>`
-                    }
+            </div>`;
+          }
 
-                    $(`#msg-history`).append(temp_html);
-                }
-            }
-
-
-        })
-    }
-
-
+          $(`#msg-history`).append(temp_html);
+        }
+      },
+    });
+  }
 </script>

--- a/docs/matching/matching-request.html
+++ b/docs/matching/matching-request.html
@@ -36,7 +36,7 @@
     window.location = "/mannerPoints/evaluate.html?matchingId="+matchingId;
 }
 function matchingCancel() {
-          window.location = `/matching-decline.html`;
+          window.location = `/matching/matching-decline.html`;
   }
 
   function matching() {

--- a/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/exception/api/Status.java
+++ b/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/exception/api/Status.java
@@ -12,8 +12,8 @@ public enum Status {
     ALREADY_FRIEND(400, "친구목록 존재하는 친구 입니다."),
     ALREADY_APPLIED_FRIEND(400, "이미 친구신청을 했습니다."),
     INVALID_EMAIL(400, "올바르지 않는 이메일 형식입니다."),
-    INVALID_PASSWORD(400, "올바르지 않는 비밀번호 형식입니다."),
-    INVALID_NICKNAME(400, "올바르지 않는 닉네임 형식입니다."),
+    INVALID_PASSWORD(400, "비밀번호는 특수문자를 제외하여 8~16글자로 입력해주세요."),
+    INVALID_NICKNAME(400, "닉네임은 특수문자를 제외하여 1~20글자까지 입력해주세요."),
 
 
     //불일치

--- a/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/member/entity/Member.java
+++ b/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.nbcamp.gamematching.matchingservice.exception.SignException;
 import com.nbcamp.gamematching.matchingservice.matching.entity.MatchingLog;
 import com.nbcamp.gamematching.matchingservice.member.domain.MemberRoleEnum;
 import jakarta.persistence.*;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -109,5 +110,23 @@ public class Member {
     public void deleteBuddy(Long memberId, Member buddy) {
         this.getMyBuddies().removeIf(member -> (member.getId() == memberId));
         buddy.getMyBuddies().removeIf(member -> (member.getId() == this.getId()));
+    }
+
+    public boolean existBuddy(Long memberId) {
+        Optional<Member> result = this.getMyBuddies().stream()
+                .filter(member -> (member.getId() == memberId)).findFirst();
+        if (result.isPresent()) {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean existBuddyRequest(Long memberId) {
+        Optional<Member> result = this.getNotYetBuddies().stream()
+                .filter(member -> (member.getId() == memberId)).findFirst();
+        if (result.isPresent()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/member/entity/Profile.java
+++ b/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/member/entity/Profile.java
@@ -23,7 +23,7 @@ public class Profile {
     private String nickname;
 
     @Column
-    private String profileImage;
+    private String profileImage = "images/man.png";
 
     @Enumerated(EnumType.STRING)
     private Tier tier;
@@ -35,13 +35,16 @@ public class Profile {
 
     @Builder
     public Profile(String nickname, String profileImage, Tier tier, GameType game) {
-        if (Pattern.matches(".*[ㄱ-ㅎㅏ-ㅣ가-힣|a-z|A-Z|]{1,20}.*", nickname)) {
+        if (Pattern.matches("[ㄱ-ㅎ가-힣a-zA-Z0-9]{1,20}", nickname)) {
             this.nickname = nickname;
         } else {
             throw new InvalidNickname();
         }
 
-        this.profileImage = profileImage;
+        if (profileImage != null) {
+            this.profileImage = profileImage;
+        }
+
 
         if (Tier.isContains(tier)) {
             this.tier = tier;

--- a/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/member/service/MemberServiceImpl.java
+++ b/matchingService/src/main/java/com/nbcamp/gamematching/matchingservice/member/service/MemberServiceImpl.java
@@ -151,6 +151,14 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(NotFoundMemberException::new);
         Member targetMember = memberRepository.findById(targetUserId)
                 .orElseThrow(NotFoundMemberException::new);
+        boolean ifBuddy = targetMember.existBuddy(memberId);
+        if (ifBuddy) {
+            return new ResponseEntity<>("이미 친구인 유저입니다.", HttpStatus.OK);
+        }
+        boolean existBuddyRequest = targetMember.existBuddyRequest(memberId);
+        if (existBuddyRequest) {
+            return new ResponseEntity<>("이미 친구 신청하였습니다.", HttpStatus.OK);
+        }
 
         targetMember.addNotYetBuddies(findMember);
         return new ResponseEntity<>("친구 요청되었습니다.", HttpStatus.OK);
@@ -161,6 +169,10 @@ public class MemberServiceImpl implements MemberService {
             Boolean answer) {
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
+        if (findMember.existBuddy(requestMemberId)) {
+            findMember.changeNotYetBuddies(requestMemberId, false);
+            return new ResponseEntity<>("이미 친구 등록된 유저입니다.",HttpStatus.OK);
+        }
         findMember.changeNotYetBuddies(requestMemberId, answer);
         String message = answer ? "친구 등록되었습니다." : "요청이 거부되었습니다.";
         return new ResponseEntity<>(message, HttpStatus.OK);


### PR DESCRIPTION
아래와 같은 피드백을 반영하여 로직을 재수정하였습니다.

1. 가입시에 유저 기본 이미지 없어서 프로필 사진이 깨져보임 
-> 사람 아이콘을 서버에 저장해서 가입시에 null이 아닌, 해당 아이콘을 띄우게 수정하였습니다.

2. 친구가 맺어진 유저에게 다시 친구 신청을 할 수 있음 
 -> 친구 신청을 수락하기 전에 친구인지 아닌지 검증하는 로직을 추가했습니다. 
또한 서로 친구 신청을 동시에 했고 한 쪽이 수락했을 경우, 다른 한 쪽에서 이미 친구인 친구를 다시 친구 등록을 하는 버그를 발견했습니다. 
이 문제를 막기 위해 친구 요청을 응답할 때 반드시 친구인 지 아닌 지 검증하고, 등록된 유저일 경우 친구가 등록된 유저라고 알람을 주는 기능도 추가하였습니다.

3. 닉네임 형식이 지정되지 않음 
-> 최근에 한글을 급하게 허용하면서 정규패턴식에 오류가 있었습니다. 해당 부분을 찾아내어 수정하였습니다. 현재는 특수문자 포함하지 않고 1이상 20미만 글자가 아니면 "닉네임은 특수문자를 제외하여 1~20글자까지 입력해주세요." 라는 문구가 뜨게 하였습니다.